### PR TITLE
Fix compile error on CentOS6

### DIFF
--- a/lutf8lib.c
+++ b/lutf8lib.c
@@ -8,10 +8,9 @@
 #include <assert.h>
 #include <string.h>
 
+#include "unidata.h"
 
 /* UTF-8 string operations */
-
-typedef unsigned int utfint;
 
 #define UTF8_BUFFSZ 8
 #define UTF8_MAX    0x7FFFFFFFu
@@ -117,8 +116,6 @@ static int utf8_range(const char *s, const char *e, lua_Integer *i, lua_Integer 
 
 
 /* Unicode character categories */
-
-#include "unidata.h"
 
 #define table_size(t) (sizeof(t)/sizeof((t)[0]))
 


### PR DESCRIPTION
Hello,
luautf8 occurs compile error on CentOS6.

```
gcc -O2 -fPIC -I/usr/include -c lutf8lib.c -o lutf8lib.o
In file included from lutf8lib.c:116:
unidata.h:9: error: redefinition of typedef 'utfint'
lutf8lib.c:14: note: previous declaration of 'utfint' was here
```

We can use the feature that redefinition of typedef from C11.
However, CentOS6's GCC does not support C11. Therefore luautf8 occurs compile error.