### PR TITLE
Improve grammar, spelling, and formatting of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,33 @@ UTF-8 module for Lua 5.x
 
 This module adds UTF-8 support to Lua.
 
-It use data extracted from
+It uses data extracted from
 [Unicode Character Database](http://www.unicode.org/reports/tr44/),
 and tested on Lua 5.2.3, Lua 5.3.0 and LuaJIT.
 
-parseucd.lua is a pure Lua script generate unidata.h, to support convert
-characters and check characters' category.
+parseucd.lua is a pure Lua script which generates unidata.h, to support
+converting characters and checking characters' category.
 
-It mainly used to compatible with Lua's own string module, it passed all
-string and pattern matching test in lua test suite[2].
+It is compatible with Lua's own string module and passes all
+string and pattern matching tests in the Lua test suite[2].
 
 It also adds some useful routines against UTF-8 features, such as:
-- a convenient interface to escape Unicode sequence in string. 
-- string insert/remove, since UTF-8 substring extract may expensive.
-- calculate Unicode width, useful when implement e.g. console emulator.
-- a useful interface to translate Unicode offset and byte offset.
+- a convenient interface to escape Unicode sequences in strings.
+- string insert/remove, since UTF-8 substring extraction may be expensive.
+- calculate Unicode width, useful when implementing e.g. console emulator.
+- a useful interface to translate Unicode offsets and byte offsets.
 - checking UTF-8 strings for validity and removing invalid byte sequences.
+- converting Unicode strings to normal form.
 
-Note that to avoid conflict with the Lua5.3's buitin library 'utf8',
-this library produce a file like lua-utf8.dll or lua-utf8.so. so use
+Note that to avoid conflict with Lua5.3's built-in library 'utf8',
+this library produces a file like lua-utf8.dll or lua-utf8.so. so use
 it like this:
 
 ```lua
 local utf8 = require 'lua-utf8'
 ```
 
-in your codes :-(
+in your code :-(
 
 [2]: http://www.lua.org/tests/5.2/
 
@@ -39,13 +40,13 @@ LuaRocks Installation
 ---------------------
 `luarocks install luautf8`
 
-It's now full-compatible with Lua5.3's utf8 library, so replace this
-file (and headers) with lua5.3 source's lutf8lib.c is also okay.
+It's now fully-compatible with Lua 5.3's utf8 library, so replacing this
+file (and headers) with lutf8lib.c from the Lua 5.3 sources is also okay.
 
 Usage
 -----
 
-Many routines are same as Lua's string module:
+Many routines are the same as Lua's string module:
 - `utf8.byte`
 - `utf8.char`
 - `utf8.find`
@@ -58,7 +59,7 @@ Many routines are same as Lua's string module:
 - `utf8.sub`
 - `utf8.upper`
 
-The document of these functions can be find in Lua manual[3].
+The documentation of these functions can be found in the Lua manual[3].
 
 [3]: http://www.lua.org/manual/5.2/manual.html#6.4
 
@@ -70,18 +71,17 @@ Some routines in string module needn't support Unicode:
 
 They are NOT in utf8 module.
 
-Some routines are the compatible for Lua 5.3's basic UTF-8 support
-library:
+Some routines are for compatibility with Lua 5.3's basic UTF-8 support library:
 - `utf8.offset`
 - `utf8.codepoint`
 - `utf8.codes`
 
-See Lua5.3's manual to get usage.
+See Lua5.3's manual for usage.
 
 Some routines are new, with some Unicode-spec functions:
 
 ### utf8.escape(str) -> utf8 string
-escape a str to UTF-8 format string. It support several escape format:
+escape a str to UTF-8 format string. It supports several escape formats:
 
  * `%ddd` - which ddd is a decimal number at any length:
    change Unicode code point to UTF-8 format.
@@ -99,13 +99,15 @@ print(u"%123%u123%{123}%u{123}%xABC%x{ABC}")
 print(u"%%123%?%d%%u")
 ```
 
+
 ### utf8.charpos(s[[, charpos], index]) -> charpos, code point
 convert UTF-8 position to byte offset.
 if only `index` is given, return byte offset of this UTF-8 char index.
 if both `charpos` and `index` is given, a new `charpos` will be
-calculated, by add/subtract UTF-8 char `index` to current `charpos`.
+calculated, by adding/subtracting UTF-8 char `index` to current `charpos`.
 in all cases, it returns a new char position, and code point (a
 number) at this position.
+
 
 ### utf8.next(s[, charpos[, index]]) -> charpos, code point
 iterate though the UTF-8 string s.
@@ -115,48 +117,54 @@ for pos, code in utf8.next, "utf8-string" do
    -- ...
 end
 ```
-if only `charpos` is given, return the next byte offset of in string.
-if `charpos` and `index` is given, a new `charpos` will be calculated, by
-add/subtract UTF-8 char offset to current charpos.
-in all case, it return a new char position (in bytes), and code point
+if only s and `charpos` are given, return the byte offset of the next codepoint
+in the string.
+if `charpos` and `index` are given, a new `charpos` will be calculated, by
+adding/subtracting UTF-8 char offset to current charpos.
+in all cases, it returns a new char position (in bytes), and code point
 (a number) at this position.
 
+
 ### utf8.insert(s[, idx], substring) -> new_string
-insert a substring to s. If idx is given, insert substring before char at
-this index, otherwise substring will concat to s. idx can be negative.
+insert a substring into s. If `idx` is given, insert the substring before
+the char at this index; otherwise, substring will be concatenated onto s.
+`idx` can be negative.
 
 
 ### utf8.remove(s[, start[, stop]]) -> new_string
-delete a substring in s. If neither start nor stop is given, delete the
-last UTF-8 char in s, otherwise delete char from start to end of s. if
-stop is given, delete char from start to stop (include start and stop).
-start and stop can be negative.
+delete a substring in s. If neither `start` nor `stop` is given, delete the
+last UTF-8 char in s, otherwise delete chars from `start` to the end of s. if
+`stop` is given, delete chars from `start` to `stop` (including `start` and `stop`).
+`start` and `stop` can be negative.
 
 
 ### utf8.width(s[, ambi_is_double[, default_width]]) -> width
-calculate the width of UTF-8 string s. if ambi_is_double is given, the
-ambiguous width character's width is 2, otherwise it's 1.
-fullwidth/doublewidth character's width is 2, and other character's width
-is 1.
-if default_width is given, it will be the width of unprintable character,
-used display a non-character mark for these characters.
+calculate the width of UTF-8 string s. if `ambi_is_double` is given,
+characters with ambiguous width will be treated as having width 2.
+Otherwise, they will be treated as having width 1.
+the width of fullwidth/doublewidth characters is 2, and the width of other
+characters is 1.
+if `default_width` is given, it will be used as the width of unprintable
+characters. (If you will replace unprintable characters with a placeholder,
+pass its width as `default_width`.)
 if s is a code point, return the width of this code point.
 
 
 ### utf8.widthindex(s, location[, ambi_is_double[, default_width]]) -> idx, offset, width
-return the character index at given location in string s. this is a
-reverse operation of utf8.width().
-this function return a index of location, and a offset in in UTF-8
-encoding. e.g. if cursor is at the second column (middle) of the wide
-char, offset will be 2. the width of character at idx is returned, also.
+return the character index at given location in string s, where location is
+in width units. this is the inverse operation of utf8.width().
+if the requested location does not fall at a character boundary, `offset` will be
+greater than 1; specifically, if the location is at the second column (middle)
+of a wide char, `offset` will be 2. the width of the character at idx is returned also.
 
 
 ### utf8.title(s) -> new_string
 ### utf8.fold(s) -> new_string
-convert UTF-8 string s to title-case, or folded case used to compare by
-ignore case.
-if s is a number, it's treat as a code point and return a convert code
-point (number). utf8.lower/utf8.upper has the same extension.
+converts UTF-8 string s to title-case, or folded case (used for
+case-insensitive comparison).
+if s is a number, it's treated as a code point and a converted code
+point (number) is returned.
+utf8.lower/utf8.upper has the same extension.
 
 
 ### utf8.ncasecmp(a, b) -> [-1,0,1]
@@ -216,4 +224,4 @@ Improvement needed
 
 License
 -------
-It use same license with Lua: http://www.lua.org/license.html
+It uses the same license as Lua: http://www.lua.org/license.html


### PR DESCRIPTION
In this PR, lua-utf8's README file receives some tender, loving care from a native English speaker.

The content is still the same, but just with standard English grammar.

FYA @starwing 