### PR TITLE
Fix hard crash in utf8.char() with negative values

### DIFF
--- a/lutf8lib.c
+++ b/lutf8lib.c
@@ -967,7 +967,7 @@ static int Lutf8_char (lua_State *L) {
   luaL_Buffer b;
   luaL_buffinit(L, &b);
   for (i = 1; i <= n; ++i) {
-    lua_Integer code = luaL_checkinteger(L, i);
+    lua_Unsigned code = (lua_Unsigned)luaL_checkinteger(L, i);
     luaL_argcheck(L, code <= UTF8_MAXCP, i, "value out of range");
     add_utf8char(&b, CAST(utfint, code));
   }

--- a/test.lua
+++ b/test.lua
@@ -66,6 +66,7 @@ assert_table_equal({ utf8.byte(s, 200, 100) }, {})
 
 -- test char
 assert(s == utf8.char(unpack(t)))
+assert_error(function() utf8.char(-1) end, "bad argument #1 to 'char' %(value out of range%)");
 
 -- test range
 for i = 1, #t do


### PR DESCRIPTION
If a negative number is passed in, it will always be smaller than
UTF8_MAXCP. However, once it is cast to unsigned and passed into
add_utf8char, it will become very large and exceed the max value,
triggering this line in utf8_encode: assert(x <= UTF8_MAX).

We need to convert to an unsigned integer first so we get the user
friendly error with argcheck instead of the hard assert.
This also matches the lua implementation:
https://www.lua.org/source/5.5/lutf8lib.c.html#pushutfchar