### PR TITLE
Add missing <limits.h> include for INT_MAX

### DIFF
--- a/lutf8lib.c
+++ b/lutf8lib.c
@@ -5,6 +5,7 @@
 #include <lualib.h>
 
 #include <assert.h>
+#include <limits.h>
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary

`lutf8lib.c` uses `INT_MAX` but does not include `<limits.h>`; on toolchains where it isn't pulled in transitively (observed with Apple clang 21 / macOS SDK), the build fails. This adds the missing include.

Found while building [Path of Building's SimpleGraphic host](https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic), which vendors luautf8 as a submodule, on macOS arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
